### PR TITLE
example in README broken (matrix shapes different)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ let mat: Matrix<i32> = Matrix::new();
 ### Example: Basic matrix usage
 ```rust
 // Create a matrix of default cells
-let zero: Matrix<u32> = Matrix::new(3, 3);
+let zero: Matrix<u32> = Matrix::new(2, 4);
 
 // Create a 2x4 matrix from an iterator (fill it row by row)
 let mat1: Matrix<u32> = Matrix::from_iter(2, 4, 0..);


### PR DESCRIPTION
Hi, simple fix here for the README.
I was following the documentation tutorial and the example gave me this error: 

![assertion-error-simple-matrix](https://user-images.githubusercontent.com/78221071/128642090-60023163-350e-453f-94bc-d31e6d4c993c.jpg)

After looking into it, it turned out it was because the rows of the first matrix (3) was not equal to the rows of the second matrix (2).

So, I propose the following fix: 
```rust
let zero: Matrix<u32> = Matrix::new(2, 4);
...
let mat1: Matrix<u32> = Matrix::from_iter(2, 4, 0..);
...
```
This will ensure that both have the same size and fixes the README example.